### PR TITLE
Feat/#16 Banner 추가

### DIFF
--- a/src/components/shared/Header/Headers/Headers.jsx
+++ b/src/components/shared/Header/Headers/Headers.jsx
@@ -12,6 +12,7 @@ import {
 import { CowDogHomeIcon } from "../CowDogHomeIcon";
 import { InputContainer } from "../../InputContainer/InputContainer";
 import { Button } from "../../Button";
+import { Link } from "react-router-dom";
 
 export const Headers = ({}) => {
   const [windowWidth, setWindowWidth] = useState(window.innerWidth);
@@ -36,7 +37,9 @@ export const Headers = ({}) => {
             <SignBtn>로그인</SignBtn>
             <SignBtn>회원가입</SignBtn>
           </SignBox>
-          <CowDogHomeIcon />
+          <Link to="/">
+            <CowDogHomeIcon />
+          </Link>
           <PostButtonBox width="5.5em">
             <Button label="글쓰기" />
           </PostButtonBox>
@@ -44,7 +47,9 @@ export const Headers = ({}) => {
       ) : (
         <>
           <LogoContainer>
-            <CowDogHomeIcon />
+            <Link to="/">
+              <CowDogHomeIcon />
+            </Link>
           </LogoContainer>
           <div></div>
           <InputContainer width="188.34" height="40" placeholder="통합검색">

--- a/src/components/shared/TopBanner/TopBanner.jsx
+++ b/src/components/shared/TopBanner/TopBanner.jsx
@@ -1,10 +1,21 @@
+import { styled } from "styled-components";
 import Coupon from "./CouponImage/coupon.png";
-import { GrClose } from "react-icons/gr";
+import { BiSolidDownload } from "react-icons/bi";
+import { useDispatch, useSelector } from "react-redux";
+import { closeTopBanner } from "../../../redux";
 
 export const TopBanner = ({}) => {
-  return (
+  const dispatch = useDispatch();
+  const isTopBannerOpen = useSelector((state) => state.topBanner);
+
+  const handleClick = () => {
+    dispatch(closeTopBanner());
+  };
+
+  return isTopBannerOpen ? (
     <div
       style={{
+        position: "relative",
         display: "flex",
         width: "100%",
         height: "50px",
@@ -15,26 +26,38 @@ export const TopBanner = ({}) => {
     >
       <div
         style={{
-          flex: 2,
           display: "flex",
-          justifyContent: "flex-end",
           alignItems: "center",
+          justifyContent: "center",
+          padding: "0 40px",
         }}
       >
-        <img src={Coupon} style={{ height: "40px", paddingRight: 8 }} />
-        <div style={{ color: "#ffffff" }}>
-          <span>첫 구매라면 누구나 최대</span>
-          <span>2만원 할인받기</span>
+        <img src={Coupon} style={{ height: "42px", paddingRight: 8 }} />
+        <div
+          style={{ color: "#ffffff", display: "flex", alignItems: "center" }}
+        >
+          <LightSpan>첫 구매라면 누구나 최대</LightSpan>
+          <BoldSpan>2만원 할인받기</BoldSpan>
+          <BiSolidDownload style={{ fontSize: "24px", marginLeft: "1.5px" }} />
         </div>
       </div>
-      <div style={{ flex: 1, display: "flex", justifyContent: "flex-end" }}>
+      <div
+        style={{
+          position: "absolute",
+          display: "flex",
+          right: "8px",
+          padding: "12px",
+        }}
+      >
         <button
           style={{
             backgroundColor: "transparent",
             border: "none",
+            cursor: "pointer",
           }}
+          onClick={handleClick}
         >
-          <div style={{ color: "#ffffff" }}>
+          <div style={{ color: "#ffffff", fontSize: "22px" }}>
             <svg
               stroke="currentColor"
               fill="currentColor"
@@ -47,7 +70,7 @@ export const TopBanner = ({}) => {
               <path
                 fill="none"
                 stroke="#ffffff"
-                stroke-width="2"
+                stroke-width="2.5"
                 d="M3,3 L21,21 M3,21 L21,3"
               ></path>
             </svg>
@@ -55,5 +78,20 @@ export const TopBanner = ({}) => {
         </button>
       </div>
     </div>
+  ) : (
+    <></>
   );
 };
+
+export const LightSpan = styled.span`
+  font-weight: 600;
+  font-size: 15px;
+  letter-spacing: 0.3px;
+`;
+
+export const BoldSpan = styled.span`
+  padding-left: 6px;
+  font-size: 20px;
+  font-weight: 900;
+  letter-spacing: 0.3px;
+`;

--- a/src/pages/ItemDetailPage/layout/ItemDetailLayout.jsx
+++ b/src/pages/ItemDetailPage/layout/ItemDetailLayout.jsx
@@ -1,9 +1,11 @@
-import { Content, Footer, Header, Wrapper } from "./style";
+import { Header, TopBanner } from "../../../components";
+import { Content, Footer, Wrapper } from "./style";
 
 export const ItemDetailLayout = ({ children }) => {
   return (
     <Wrapper>
-      <Header>Header</Header>
+      <TopBanner />
+      <Header />
       <Content>{children}</Content>
       <Footer>Footer</Footer>
     </Wrapper>

--- a/src/pages/MainPage/container/MainContainer.jsx
+++ b/src/pages/MainPage/container/MainContainer.jsx
@@ -1,3 +1,4 @@
+// @ts-nocheck
 import { useDispatch, useSelector } from "react-redux";
 import { MainBannerView, MainItemView } from "../view";
 import { useInView } from "react-intersection-observer";

--- a/src/redux/config/store.js
+++ b/src/redux/config/store.js
@@ -1,8 +1,9 @@
 import { configureStore } from "@reduxjs/toolkit";
-import { pageIndexReducer } from "../reducers";
+import { pageIndexReducer, topBannerReducer } from "../reducers";
 
 export const store = configureStore({
   reducer: {
     pageIndex: pageIndexReducer,
+    topBanner: topBannerReducer,
   },
 });

--- a/src/redux/reducers/index.js
+++ b/src/redux/reducers/index.js
@@ -1,1 +1,2 @@
 export * from "./pageIndex";
+export * from "./topBanner";

--- a/src/redux/reducers/topBanner.js
+++ b/src/redux/reducers/topBanner.js
@@ -1,0 +1,13 @@
+import { createSlice } from "@reduxjs/toolkit";
+
+const topBanner = createSlice({
+  name: "topBanner",
+  initialState: true,
+  reducers: {
+    closeTopBanner: (state) => !state,
+  },
+});
+
+export const { closeTopBanner } = topBanner.actions;
+
+export const topBannerReducer = topBanner.reducer;


### PR DESCRIPTION
1. global하게 쓰일 수 있는 banner 추가
- redux 사용
- Login/ SignUp 제외 시 Layout에 추가해주시면 새로고침 되지 않는 한 Banner를 한 번 닫으면 다시 열리지 않습니다.

2. Header 변경
- 로고를 누르면 홈 route로 이동하지 않는 점 개선 (Link 태그 추가)